### PR TITLE
Could you bump the dependency on time to 1.2.0.5?

### DIFF
--- a/convertible.cabal
+++ b/convertible.cabal
@@ -50,7 +50,7 @@ flag time_gte_113
 
 library
   if flag(splitBase)
-    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.2.0.3,
+    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.2.0.5,
      bytestring, containers, old-locale
     if flag(time_gte_113)
       Build-Depends: time>=1.1.3


### PR DESCRIPTION
I need to use 1.2.0.5 because it fixes a bug where parseTime was not handling padding properly. This dependency is making cabal choke. 

Thanks!
