### PR TITLE
Relax dependency on time.

### DIFF
--- a/convertible.cabal
+++ b/convertible.cabal
@@ -50,7 +50,7 @@ flag time_gte_113
 
 library
   if flag(splitBase)
-    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.2.0.5,
+    Build-Depends: base>=3 && <5, old-time, time>=1.1.2.4 && <=1.5,
      bytestring, containers, old-locale
     if flag(time_gte_113)
       Build-Depends: time>=1.1.3


### PR DESCRIPTION
I tested this with GHC 6.12.3, 7.0.3, 7.2.1and 7.4.0.21111219, and with time 1.2, 1.3 and 1.4 (though not in all
permutations).
