### PR TITLE
Remove unused import and export.

### DIFF
--- a/Data/Convertible.hs
+++ b/Data/Convertible.hs
@@ -31,10 +31,9 @@ for you.
 
 module Data.Convertible (
                          module Data.Convertible.Base,
-                         module Data.Convertible.Utils,
-                         module Data.Convertible.Instances
+                         module Data.Convertible.Utils
                          )
 where
 import Data.Convertible.Base
 import Data.Convertible.Utils
-import Data.Convertible.Instances
+import Data.Convertible.Instances ()

--- a/Data/Convertible/Instances/Time.hs
+++ b/Data/Convertible/Instances/Time.hs
@@ -29,7 +29,6 @@ import Data.Convertible.Utils
 import Data.Convertible.Instances.Num()
 import qualified System.Time as ST
 import Data.Time
-import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Data.Time.Calendar.OrdinalDate
 #ifndef TIME_GT_113


### PR DESCRIPTION
This fixes some warnings. There is one still left due to the deprecated 'mkTyCon', but I wasn't sure if and how you wanted to deal with that.
