### PR TITLE
Add MonadFail instance for Either ConvertError

### DIFF
--- a/Data/Convertible/Base.hs
+++ b/Data/Convertible/Base.hs
@@ -28,11 +28,15 @@ module Data.Convertible.Base( -- * The conversion process
                               prettyConvertError
                              )
 where
+import Control.Monad.Fail
 import Control.Monad.Error
 import Data.Typeable
 
 {- | The result of a safe conversion via 'safeConvert'. -}
 type ConvertResult a = Either ConvertError a
+
+instance MonadFail (Either ConvertError) where
+    fail = Left . strMsg
 
 ----------------------------------------------------------------------
 -- Conversions

--- a/convertible.cabal
+++ b/convertible.cabal
@@ -52,6 +52,7 @@ source-repository head
 
 library
   Build-Depends: base>=3 && <5,
+                 fail,
                  old-time,
                  time>=1.1.3,
                  bytestring >= 0.10.2,


### PR DESCRIPTION
This makes it so you can call `fail` from within `Convertible` instances starting with GHC 8.8.1. 