### PR TITLE
Compatibility with mtl 2.3

### DIFF
--- a/Data/Convertible/Base.hs
+++ b/Data/Convertible/Base.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-
 Copyright (C) 2009-2011 John Goerzen <jgoerzen@complete.org>
 
@@ -28,7 +29,9 @@ module Data.Convertible.Base( -- * The conversion process
                               prettyConvertError
                              )
 where
+#if !MIN_VERSION_mtl(2,3,0)
 import Control.Monad.Error
+#endif
 import Data.Typeable
 
 {- | The result of a safe conversion via 'safeConvert'. -}
@@ -89,8 +92,10 @@ data ConvertError = ConvertError {
       convErrorMessage :: String}
                     deriving (Eq, Read, Show)
 
+#if !MIN_VERSION_mtl(2,3,0)
 instance Error ConvertError where
     strMsg x = ConvertError "(unknown)" "(unknown)" "(unknown)" x
+#endif
 
 convError' :: (Show a, Typeable a, Typeable b) =>
                String -> a -> b -> ConvertResult b


### PR DESCRIPTION
Mtl 2.3 will have this deprecated class removed. To ensure compatibility
with the release when it comes out, define its instance only
conditionally.

Tested with mtl-2.3 and with mtl-2.2.2. (EDIT: updated in May to test with the now-released mtl-2.3)